### PR TITLE
Fix annotSV from bed converter

### DIFF
--- a/variantconvert/commons.py
+++ b/variantconvert/commons.py
@@ -170,6 +170,14 @@ def create_vcf_header(input_path, config, sample_list, breakpoints=False):
     )
     return header
 
+def remove_decimal_or_strip(value):
+   #Due to string value info field 
+    if value.endswith('.0'):
+        value = str(int(float(value)))
+    #forbidden to have blank space in vcf info field
+    else:
+        value = value.strip().replace(' ', '')
+    return value
 
 if __name__ == "__main__":
     pass

--- a/variantconvert/commons.py
+++ b/variantconvert/commons.py
@@ -50,6 +50,7 @@ def rename_duplicates_in_list(input_list):
             output_list.append(e + "_" + str(elt_counts[e_lower]))
     return output_list
 
+
 def is_helper_func(arg):
     if isinstance(arg, list):
         if arg[0] == "HELPER_FUNCTION":
@@ -117,7 +118,10 @@ def create_vcf_header(input_path, config, sample_list, breakpoints=False):
 
     # TODO: FILTER is not present in any tool implemented yet
     # so all variants are set to PASS
-    if config["VCF_COLUMNS"]["FILTER"] != "" and config["GENERAL"]["origin"] != "AnnotSV":
+    if (
+        config["VCF_COLUMNS"]["FILTER"] != ""
+        and config["GENERAL"]["origin"] != "AnnotSV"
+    ):
         raise ValueError(
             "Filters are not implemented yet. "
             'Leave config["COLUMNS_DESCRIPTION"]["FILTER"] empty '
@@ -135,9 +139,15 @@ def create_vcf_header(input_path, config, sample_list, breakpoints=False):
         info_dic = config["COLUMNS_DESCRIPTION"]["INFO"]
         if breakpoints:
             if "SVTYPE" not in info_dic.keys():
-                info_dic["SVTYPE"] = {"Type":"String", "Description":"Type of structural variant"}
+                info_dic["SVTYPE"] = {
+                    "Type": "String",
+                    "Description": "Type of structural variant",
+                }
             if "MATEDID" not in info_dic.keys():
-                info_dic["MATEID"] = {"Type":"String", "Description":"ID of mate breakends"}
+                info_dic["MATEID"] = {
+                    "Type": "String",
+                    "Description": "ID of mate breakends",
+                }
 
         for key, dic in info_dic.items():
             header.append(
@@ -170,14 +180,16 @@ def create_vcf_header(input_path, config, sample_list, breakpoints=False):
     )
     return header
 
+
 def remove_decimal_or_strip(value):
-   #Due to string value info field 
-    if value.endswith('.0'):
+    # Due to string value info field
+    if value.endswith(".0"):
         value = str(int(float(value)))
-    #forbidden to have blank space in vcf info field
+    # forbidden to have blank space in vcf info field
     else:
-        value = value.strip().replace(' ', '')
+        value = value.replace(" ", "_")
     return value
+
 
 if __name__ == "__main__":
     pass

--- a/variantconvert/converters/vcf_from_annotsv.py
+++ b/variantconvert/converters/vcf_from_annotsv.py
@@ -13,7 +13,7 @@ from natsort import index_natsorted
 from converters.abstract_converter import AbstractConverter
 
 sys.path.append("..")
-from commons import create_vcf_header, is_helper_func
+from commons import create_vcf_header, is_helper_func, remove_decimal_or_strip
 from helper_functions import HelperFunctions
 
 
@@ -64,7 +64,7 @@ class VcfFromAnnotsv(AbstractConverter):
                 raise ValueError(
                     "When using an AnnotSV file generated from a VCF, all samples in '" + samples_col + "' column are expected to "
                     "have their own column in the input AnnotSV file"
-            )
+            ) 
         return sample_list
 
     def _build_input_annot_df(self):
@@ -109,18 +109,20 @@ class VcfFromAnnotsv(AbstractConverter):
                 "Unexpected value in json config['GENERAL']['mode']: "
                 "only 'full&split' mode is implemented yet."
             )
-
+       #Do not keep 'base vcf col' in info field
+        df = df.loc[:, [cols for cols in df.columns if cols not in ['ID', 'REF', 'ALT', 'QUAL', 'FILTER']]]  
+        except_full_list = ['Gene_name', 'ACMG_class'] 
         annots = {}
         dfs = {}
-        for type, df_type in df.groupby(
+        for typemode, df_type in df.groupby(
             self.config["VCF_COLUMNS"]["INFO"]["Annotation_mode"]
         ):
-            if type not in ("full", "split"):
+            if typemode not in ("full", "split"):
                 raise ValueError(
                     "Annotation type is assumed to be only 'full' or 'split'"
                 )
-            dfs[type] = df_type
-
+            dfs[typemode] = df_type
+        
         # deal with full
         if "full" not in dfs.keys():
             # still need to init columns
@@ -136,22 +138,36 @@ class VcfFromAnnotsv(AbstractConverter):
                 raise ValueError(
                     "Each variant is assumed to only have one single line of 'full' annotation"
                 )
+            #remove float decimal full rows   
             for ann in dfs["full"].columns:
-                annots[ann] = dfs["full"].loc[df.index[0], ann]
+                annots[ann] = remove_decimal_or_strip(dfs["full"].loc[df.index[0], ann])
 
         # deal with split
         if "split" not in dfs.keys():
             return annots
+        #each info field split 
         for ann in dfs["split"].columns:
+            transform = [] 
             if ann == self.config["VCF_COLUMNS"]["INFO"]["Annotation_mode"]:
                 annots[ann] = self.config["GENERAL"]["mode"]
                 continue
-            if annots[ann] != ".":
-                continue  #'full' annot is always prioritized
-            annots[ann] = ",".join(dfs["split"][ann].tolist())
+            #if you only keep full annotations split is lost advitam eternam 
+            #list of all values in each columns 
+            for splitval in dfs["split"][ann].tolist():
+                transform.append(remove_decimal_or_strip(splitval))
+            #we don't report split infos only if there are ALL equal to full row or they are stack to dot 
+            if all([nq == annots[ann] for nq in transform]) or all(eq == '.' for eq in transform) or ann in except_full_list:
+                continue
+           #In case of full and n split are different we keep values from all (more than 2 differencies)
+            else:
+                values = [annots[ann]]
+                values.extend(transform)
+                annots[ann] = "|".join(values)
+                #TODO in case of pipe already present in annotations change separator, maybe '+'  
 
         # remove empty annots
-        annots = {k: v for k, v in annots.items() if v != "."}
+        annots = {k: v for k, v in annots.items()}
+        #annots = {k: int(v) for k, v in annots.items() if isinstance(v, float)}
         return annots
 
     def _build_info_dic(self):
@@ -166,8 +182,8 @@ class VcfFromAnnotsv(AbstractConverter):
         for variant_id, df_variant in input_annot_df.groupby(id_col):
             merged_annots = self._merge_full_and_split(df_variant)
             annots_dic[variant_id] = merged_annots
-        print("annots_dic")
-        print(annots_dic)
+        #print("annots_dic")
+        #print(annots_dic)
         return annots_dic
 
     # TODO: merge this with the other create_vcf_header method if possible
@@ -352,6 +368,5 @@ class VcfFromAnnotsv(AbstractConverter):
                     )
                 else:
                     sample_cols = "GT\t" + self.config["GENERAL"]["default_genotype"]
-
                 vcf.write(sample_cols)
                 vcf.write("\n")

--- a/variantconvert/converters/vcf_from_annotsv.py
+++ b/variantconvert/converters/vcf_from_annotsv.py
@@ -62,9 +62,11 @@ class VcfFromAnnotsv(AbstractConverter):
         if self.config["VCF_COLUMNS"]["FORMAT"] == "FORMAT":
             if not set(sample_list).issubset(self.input_df.columns):
                 raise ValueError(
-                    "When using an AnnotSV file generated from a VCF, all samples in '" + samples_col + "' column are expected to "
+                    "When using an AnnotSV file generated from a VCF, all samples in '"
+                    + samples_col
+                    + "' column are expected to "
                     "have their own column in the input AnnotSV file"
-            ) 
+                )
         return sample_list
 
     def _build_input_annot_df(self):
@@ -86,13 +88,16 @@ class VcfFromAnnotsv(AbstractConverter):
             ";", ",", regex=True
         )  # any ';' in annots will ruin the vcf INFO field
 
-        #TODO: check if CHROM col is in compliance with config ref genome (chrX or X)
+        # TODO: check if CHROM col is in compliance with config ref genome (chrX or X)
         # if self.config["GENOME"]["vcf_header"][0].startswith("##contig=<ID=chr"):
-        #     if not chrom.startswith 
+        #     if not chrom.startswith
 
-        if self.config["VCF_COLUMNS"]["INFO"]["SV_type"] == "" or self.config["VCF_COLUMNS"]["INFO"]["SV_type"] not in df.columns:
+        if (
+            self.config["VCF_COLUMNS"]["INFO"]["SV_type"] == ""
+            or self.config["VCF_COLUMNS"]["INFO"]["SV_type"] not in df.columns
+        ):
             raise ValueError(
-                "SV_type column is required to turn an AnnotSV file into a VCF. Check if SV_type col is set in config or missing in your file.\n" \
+                "SV_type column is required to turn an AnnotSV file into a VCF. Check if SV_type col is set in config or missing in your file.\n"
                 + "If you generated your AnnotSV file from a bed, AnnotSV option -svtBEDcol is required."
             )
         return df
@@ -109,9 +114,16 @@ class VcfFromAnnotsv(AbstractConverter):
                 "Unexpected value in json config['GENERAL']['mode']: "
                 "only 'full&split' mode is implemented yet."
             )
-       #Do not keep 'base vcf col' in info field
-        df = df.loc[:, [cols for cols in df.columns if cols not in ['ID', 'REF', 'ALT', 'QUAL', 'FILTER']]]  
-        except_full_list = ['Gene_name', 'ACMG_class'] 
+        # Do not keep 'base vcf col' in info field
+        df = df.loc[
+            :,
+            [
+                cols
+                for cols in df.columns
+                if cols not in ["ID", "REF", "ALT", "QUAL", "FILTER"]
+            ],
+        ]
+        # except_full_list = ['Gene_name', 'ACMG_class']
         annots = {}
         dfs = {}
         for typemode, df_type in df.groupby(
@@ -122,7 +134,7 @@ class VcfFromAnnotsv(AbstractConverter):
                     "Annotation type is assumed to be only 'full' or 'split'"
                 )
             dfs[typemode] = df_type
-        
+
         # deal with full
         if "full" not in dfs.keys():
             # still need to init columns
@@ -138,36 +150,39 @@ class VcfFromAnnotsv(AbstractConverter):
                 raise ValueError(
                     "Each variant is assumed to only have one single line of 'full' annotation"
                 )
-            #remove float decimal full rows   
+            # remove float decimal full rows
             for ann in dfs["full"].columns:
                 annots[ann] = remove_decimal_or_strip(dfs["full"].loc[df.index[0], ann])
 
         # deal with split
         if "split" not in dfs.keys():
             return annots
-        #each info field split 
+        # each info field split
         for ann in dfs["split"].columns:
-            transform = [] 
+            transform = []
             if ann == self.config["VCF_COLUMNS"]["INFO"]["Annotation_mode"]:
                 annots[ann] = self.config["GENERAL"]["mode"]
                 continue
-            #if you only keep full annotations split is lost advitam eternam 
-            #list of all values in each columns 
+            # if you only keep full annotations split is lost advitam eternam
+            # list of all values in each columns
             for splitval in dfs["split"][ann].tolist():
                 transform.append(remove_decimal_or_strip(splitval))
-            #we don't report split infos only if there are ALL equal to full row or they are stack to dot 
-            if all([nq == annots[ann] for nq in transform]) or all(eq == '.' for eq in transform) or ann in except_full_list:
-                continue
-           #In case of full and n split are different we keep values from all (more than 2 differencies)
-            else:
-                values = [annots[ann]]
-                values.extend(transform)
-                annots[ann] = "|".join(values)
-                #TODO in case of pipe already present in annotations change separator, maybe '+'  
+            # we don't report split infos only if there are ALL equal to full row or they are stack to dot
+            # if all([nq == annots[ann] for nq in transform]) or all(
+            #     eq == "." for eq in transform
+            # ):  # or ann in except_full_list:
+
+            #    continue
+            # In case of full and n split are different we keep values from all (more than 2 differencies)
+            # else:
+            values = [annots[ann]]
+            values.extend(transform)
+            annots[ann] = "|".join(values)
+            # TODO in case of pipe already present in annotations change separator, maybe '+'
 
         # remove empty annots
         annots = {k: v for k, v in annots.items()}
-        #annots = {k: int(v) for k, v in annots.items() if isinstance(v, float)}
+        # annots = {k: int(v) for k, v in annots.items() if isinstance(v, float)}
         return annots
 
     def _build_info_dic(self):
@@ -182,8 +197,8 @@ class VcfFromAnnotsv(AbstractConverter):
         for variant_id, df_variant in input_annot_df.groupby(id_col):
             merged_annots = self._merge_full_and_split(df_variant)
             annots_dic[variant_id] = merged_annots
-        #print("annots_dic")
-        #print(annots_dic)
+        # print("annots_dic")
+        # print(annots_dic)
         return annots_dic
 
     # TODO: merge this with the other create_vcf_header method if possible
@@ -333,16 +348,20 @@ class VcfFromAnnotsv(AbstractConverter):
                 vcf.write(l + "\n")
 
             id_col = self.config["VCF_COLUMNS"]["INFO"]["AnnotSV_ID"]
-            self.input_df = self.input_df.iloc[index_natsorted(self.input_df[self.config["VCF_COLUMNS"]["#CHROM"]])]
+            self.input_df = self.input_df.iloc[
+                index_natsorted(self.input_df[self.config["VCF_COLUMNS"]["#CHROM"]])
+            ]
 
             for variant_id, df_variant in self.input_df.groupby(id_col, sort=False):
 
-                #fill columns that need a helper func
+                # fill columns that need a helper func
                 for config_key, config_val in self.config["VCF_COLUMNS"].items():
                     if config_key == "INFO":
                         for info_col in self.config["VCF_COLUMNS"][config_key].values():
                             if is_helper_func(info_col):
-                                raise ValueError("HELPER_FUNCTIONS for INFO fields are not implemented yet for AnnotSV converter")
+                                raise ValueError(
+                                    "HELPER_FUNCTIONS for INFO fields are not implemented yet for AnnotSV converter"
+                                )
                     elif config_key == "FILTER" and config_val == "":
                         df_variant[config_key] = "PASS"
                     elif is_helper_func(config_val):


### PR DESCRIPTION
- Remove useless .0 for integer values in vcf INFO field
- Keep full and all split annotations in vcf INFO field separate by PIPE (full|split|....| n split)
- replace blankspace by '_' in vcf INFO field to avoid IGV crash when loading vcf generated by variantconvert